### PR TITLE
Add Node.js v22 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [18, 20]
+        version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": "github:CargoSense/stylelint-config-scss",
   "scripts": {
-    "test": "NODE_V8_COVERAGE=coverage node --experimental-test-coverage --test ./test"
+    "test": "NODE_V8_COVERAGE=coverage node --experimental-test-coverage --test"
   },
   "dependencies": {
     "@stylistic/stylelint-config": "^1.0.1",


### PR DESCRIPTION
Does exactly what it says on the tin! [Node.js v22](https://nodejs.org/en) is the "current" release line.