### PR TITLE
Update Stylelint dev dependency to v16.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "stylelint-order": "^6.0.4"
       },
       "devDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^16.6.0"
       },
       "engines": {
         "node": ">=18.12.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "stylelint-order": "^6.0.4"
   },
   "devDependencies": {
-    "stylelint": "^16.1.0"
+    "stylelint": "^16.6.0"
   },
   "peerDependencies": {
     "stylelint": ">=16.1"


### PR DESCRIPTION
Release Notes for each updated version:

- https://github.com/stylelint/stylelint/releases/tag/16.2.0
- https://github.com/stylelint/stylelint/releases/tag/16.2.1
- https://github.com/stylelint/stylelint/releases/tag/16.3.0
- https://github.com/stylelint/stylelint/releases/tag/16.3.1
- https://github.com/stylelint/stylelint/releases/tag/16.4.0
- https://github.com/stylelint/stylelint/releases/tag/16.5.0
- https://github.com/stylelint/stylelint/releases/tag/16.6.0

Each release includes fixes and a few backward-compatible additions.
