### PR TITLE
Update stylelint-config-standard-scss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stylistic/stylelint-config": "^1.0.1",
-        "stylelint-config-standard-scss": "^13.0.0",
+        "stylelint-config-standard-scss": "^13.1.0",
         "stylelint-order": "^6.0.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cargosense/stylelint-config-scss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cargosense/stylelint-config-scss",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@stylistic/stylelint-config": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@stylistic/stylelint-config": "^1.0.1",
-    "stylelint-config-standard-scss": "^13.0.0",
+    "stylelint-config-standard-scss": "^13.1.0",
     "stylelint-order": "^6.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cargosense/stylelint-config-scss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shareable Stylelint configuration for SCSS syntax Sass files.",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
Release Notes:

- https://github.com/stylelint-scss/stylelint-config-standard-scss/releases

I'm considering this change worthy enough to warrant a minor version bump (since it changed the shape of the `dependencies`).